### PR TITLE
support zipkin b3 propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
+ "opentelemetry-zipkin",
  "opentelemetry_sdk",
  "prometheus",
  "reqwest",
@@ -1156,6 +1157,27 @@ name = "opentelemetry-semantic-conventions"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry-zipkin"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6943c09b1b7c17b403ae842b00f23e6d5fc6f5ec06cccb3f39aca97094a899a"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "typed-builder",
+]
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -2170,6 +2192,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-builder"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "unicase"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ of requests across services.
 To enable tracing you must:
 
 - use the SDK option `--otlp-endpoint` e.g. `http://localhost:4317`,
-- set the SDK environment variable `OTLP_ENDPOINT`, or
+- set the SDK environment variable `OTEL_EXPORTER_OTLP_ENDPOINT`, or
 - set the `tracing` environment variable `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
 
 For additional service information you can:

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -39,6 +39,7 @@ opentelemetry-http = "0.11.0"
 opentelemetry-otlp = { version = "0.15.0", features = ["reqwest-client"] }
 opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
+opentelemetry-zipkin = "0.20.0"
 prometheus = "0.13.3"
 reqwest = "0.11.27"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
Connectors should support both W3C and Zipkin B3 propagation. B3 propagation headers priority should be higher because W3C traceparent header is intercepted by Cloud Run service.