### PR TITLE
Pass rustls flag onto opentelemetry-http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls 0.21.10",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbfa5308166ca861434f0b0913569579b8e587430a3d6bcd7fd671921ec145a"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1480,6 +1494,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1491,6 +1506,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -1499,6 +1515,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -1567,6 +1584,18 @@ dependencies = [
  "rustls-webpki 0.102.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2079,6 +2108,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
@@ -2133,11 +2172,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -19,7 +19,7 @@ path = "bin/main.rs"
 default = ["native-tls", "ndc-test"]
 
 native-tls = ["reqwest/native-tls"]
-rustls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls", "opentelemetry-http/reqwest-rustls"]
 
 ndc-test = ["dep:ndc-test"]
 
@@ -35,7 +35,7 @@ clap = { version = "4.5.4", features = ["derive", "env"] }
 http = "0.2"
 mime = "0.3.17"
 opentelemetry = "0.22.0"
-opentelemetry-http = "0.11.0"
+opentelemetry-http = "0.11.1"
 opentelemetry-otlp = { version = "0.15.0", features = ["reqwest-client", "gzip-tonic", "tls", "tls-roots", "http-proto"] }
 opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -19,7 +19,7 @@ path = "bin/main.rs"
 default = ["native-tls", "ndc-test"]
 
 native-tls = ["reqwest/native-tls"]
-rustls = ["reqwest/rustls", "opentelemetry-http/reqwest-rustls"]
+rustls = ["reqwest/rustls"]
 
 ndc-test = ["dep:ndc-test"]
 
@@ -36,10 +36,10 @@ http = "0.2"
 mime = "0.3.17"
 opentelemetry = "0.22.0"
 opentelemetry-http = "0.11.1"
-opentelemetry-otlp = { version = "0.15.0", features = ["reqwest-client", "gzip-tonic", "tls", "tls-roots", "http-proto"] }
+opentelemetry-otlp = { version = "0.15.0", features = ["reqwest-rustls", "gzip-tonic", "tls", "tls-roots", "http-proto"] }
 opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
-opentelemetry-zipkin = "0.20.0"
+opentelemetry-zipkin = { version = "0.20.0", default-features = false, features = ["reqwest-rustls"] }
 prometheus = "0.13.3"
 reqwest = "0.11.27"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
When consumers of this library ask for `rustls` we need to ask `opentelemetry-http` for it too. This requires a version bump for it, but adding the flag is the only thing said bump does: https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-http/CHANGELOG.md#v0111