### PR TITLE
HTTP/2 support.

### DIFF
--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -28,7 +28,7 @@ ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.2" }
 ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.2", optional = true }
 
 async-trait = "0.1.79"
-axum = "0.6.20"
+axum = { version = "0.6.20", features = ["http2"] }
 axum-extra = "0.8.0"
 bytes = "1.6.0"
 clap = { version = "4.5.4", features = ["derive", "env"] }


### PR DESCRIPTION
Enable HTTP/2 support for Axum, so that we can make use of request multiplexing from the engine.