### PR TITLE
Insert ndc-spec version into CapabilitiesResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,13 +954,15 @@ dependencies = [
 [[package]]
 name = "ndc-models"
 version = "0.1.4"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.4#20172e3b2552b78d16dbafcd047f559ced420309"
+source = "git+http://github.com/hasura/ndc-spec.git#630dafaa2a0c90ab74413303680901289d510727"
 dependencies = [
  "indexmap 2.2.6",
+ "ref-cast",
  "schemars",
  "serde",
  "serde_json",
  "serde_with",
+ "smol_str",
 ]
 
 [[package]]
@@ -999,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.4"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.4#20172e3b2552b78d16dbafcd047f559ced420309"
+source = "git+http://github.com/hasura/ndc-spec.git#630dafaa2a0c90ab74413303680901289d510727"
 dependencies = [
  "async-trait",
  "clap",
@@ -1011,6 +1013,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "smol_str",
  "thiserror",
  "tokio",
  "url",
@@ -1413,6 +1416,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,15 +954,13 @@ dependencies = [
 [[package]]
 name = "ndc-models"
 version = "0.1.4"
-source = "git+http://github.com/hasura/ndc-spec.git#630dafaa2a0c90ab74413303680901289d510727"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=002923d5c337930b9c9007f05c768fe9a0575612#002923d5c337930b9c9007f05c768fe9a0575612"
 dependencies = [
  "indexmap 2.2.6",
- "ref-cast",
  "schemars",
  "serde",
  "serde_json",
  "serde_with",
- "smol_str",
 ]
 
 [[package]]
@@ -1001,7 +999,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.1.4"
-source = "git+http://github.com/hasura/ndc-spec.git#630dafaa2a0c90ab74413303680901289d510727"
+source = "git+http://github.com/hasura/ndc-spec.git?rev=002923d5c337930b9c9007f05c768fe9a0575612#002923d5c337930b9c9007f05c768fe9a0575612"
 dependencies = [
  "async-trait",
  "clap",
@@ -1013,7 +1011,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "smol_str",
  "thiserror",
  "tokio",
  "url",
@@ -1416,26 +1413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.55",
 ]
 
 [[package]]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -24,8 +24,8 @@ rustls = ["reqwest/rustls"]
 ndc-test = ["dep:ndc-test"]
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.4" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.4", optional = true }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", optional = true }
 
 async-trait = "0.1.79"
 axum = { version = "0.6.20", features = ["http2"] }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -24,8 +24,8 @@ rustls = ["reqwest/rustls"]
 ndc-test = ["dep:ndc-test"]
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", optional = true }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", rev = "002923d5c337930b9c9007f05c768fe9a0575612"}
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", rev = "002923d5c337930b9c9007f05c768fe9a0575612", optional = true }
 
 async-trait = "0.1.79"
 axum = { version = "0.6.20", features = ["http2"] }

--- a/crates/sdk/src/connector.rs
+++ b/crates/sdk/src/connector.rs
@@ -69,7 +69,7 @@ pub trait Connector {
     ///
     /// This function implements the [capabilities endpoint](https://hasura.github.io/ndc-spec/specification/capabilities.html)
     /// from the NDC specification.
-    async fn get_capabilities() -> JsonResponse<models::CapabilitiesResponse>;
+    async fn get_capabilities() -> models::Capabilities;
 
     /// Get the connector's schema.
     ///

--- a/crates/sdk/src/connector/example.rs
+++ b/crates/sdk/src/connector/example.rs
@@ -48,28 +48,24 @@ impl Connector for Example {
         Ok(())
     }
 
-    async fn get_capabilities() -> JsonResponse<models::CapabilitiesResponse> {
-        models::CapabilitiesResponse {
-            version: "0.1.4".into(),
-            capabilities: models::Capabilities {
-                relationships: None,
-                query: models::QueryCapabilities {
-                    variables: None,
+    async fn get_capabilities() -> models::Capabilities {
+        models::Capabilities {
+            relationships: None,
+            query: models::QueryCapabilities {
+                variables: None,
+                aggregates: None,
+                explain: None,
+                nested_fields: models::NestedFieldCapabilities {
+                    filter_by: None,
+                    order_by: None,
                     aggregates: None,
-                    explain: None,
-                    nested_fields: models::NestedFieldCapabilities {
-                        filter_by: None,
-                        order_by: None,
-                        aggregates: None,
-                    },
-                },
-                mutation: models::MutationCapabilities {
-                    transactional: None,
-                    explain: None,
                 },
             },
+            mutation: models::MutationCapabilities {
+                transactional: None,
+                explain: None,
+            },
         }
-        .into()
     }
 
     async fn get_schema(

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -381,8 +381,9 @@ async fn get_capabilities<C: Connector>() -> JsonResponse<CapabilitiesResponse> 
     let capabilities = C::get_capabilities().await;
     CapabilitiesResponse {
         version: ndc_models::VERSION.into(),
-        capabilities
-    }.into()
+        capabilities,
+    }
+    .into()
 }
 
 async fn get_health<C: Connector>(State(state): State<ServerState<C>>) -> Result<(), HealthError> {

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -378,7 +378,11 @@ async fn get_metrics<C: Connector>(
 }
 
 async fn get_capabilities<C: Connector>() -> JsonResponse<CapabilitiesResponse> {
-    C::get_capabilities().await
+    let capabilities = C::get_capabilities().await;
+    CapabilitiesResponse {
+        version: ndc_models::VERSION.into(),
+        capabilities
+    }.into()
 }
 
 async fn get_health<C: Connector>(State(state): State<ServerState<C>>) -> Result<(), HealthError> {
@@ -441,7 +445,7 @@ mod ndc_test_commands {
         async fn get_capabilities(
             &self,
         ) -> Result<ndc_models::CapabilitiesResponse, ndc_test::error::Error> {
-            C::get_capabilities()
+            super::get_capabilities::<C>()
                 .await
                 .into_value::<Box<dyn std::error::Error>>()
                 .map_err(ndc_test::error::Error::OtherError)


### PR DESCRIPTION
SDK now builds the CapabilitiesResponse, and insert the correct NDC spec version, instead of expecting the connector to do it. 