### PR TITLE
Add `ndc_models_version` to `try_init_state`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1011,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "versions",
 ]
 
 [[package]]
@@ -1017,6 +1033,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1358,7 +1384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.55",
@@ -2409,6 +2435,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "versions"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc28d1172a20e32754969ea1a873c2c6e68e36c449c6056aa3e2ee5fe69a794"
+dependencies = [
+ "itertools 0.13.0",
+ "nom",
+]
 
 [[package]]
 name = "want"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -51,6 +51,7 @@ tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "fmt", "json"] }
 url = "2.5.0"
+versions = "6.3.0"
 
 [dev-dependencies]
 axum-test-helper = "0.3.0"

--- a/crates/sdk/src/connector.rs
+++ b/crates/sdk/src/connector.rs
@@ -148,5 +148,6 @@ pub trait ConnectorSetup {
         &self,
         configuration: &<Self::Connector as Connector>::Configuration,
         metrics: &mut prometheus::Registry,
+        ndc_models_versions: &Option<versions::SemVer>,
     ) -> Result<<Self::Connector as Connector>::State, InitializationError>;
 }

--- a/crates/sdk/src/connector/example.rs
+++ b/crates/sdk/src/connector/example.rs
@@ -24,6 +24,7 @@ impl ConnectorSetup for Example {
         &self,
         _configuration: &<Self as Connector>::Configuration,
         _metrics: &mut prometheus::Registry,
+        _ndc_models_version: &Option<versions::SemVer>,
     ) -> Result<<Self as Connector>::State, InitializationError> {
         Ok(())
     }

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -289,7 +289,9 @@ pub async fn init_server_state<Setup: ConnectorSetup>(
 ) -> Result<ServerState<Setup::Connector>, Box<dyn Error + Send + Sync>> {
     let mut metrics = Registry::new();
     let configuration = setup.parse_configuration(config_directory).await?;
-    let state = setup.try_init_state(&configuration, &mut metrics).await?;
+    let state = setup
+        .try_init_state(&configuration, &mut metrics, &None)
+        .await?;
     Ok(ServerState::new(configuration, state, metrics))
 }
 
@@ -582,7 +584,9 @@ mod ndc_test_commands {
     ) -> Result<ConnectorAdapter<Setup::Connector>, Box<dyn Error + Send + Sync>> {
         let mut metrics = Registry::new();
         let configuration = setup.parse_configuration(configuration_path).await?;
-        let state = setup.try_init_state(&configuration, &mut metrics).await?;
+        let state = setup
+            .try_init_state(&configuration, &mut metrics, &None)
+            .await?;
         Ok(ConnectorAdapter {
             configuration,
             state,


### PR DESCRIPTION
It will be useful to have some behaviour depend on the `ndc_models` version being used, so making this available in `try_init_state`.