### PR TITLE
listen on all ipv4 and ipv6 interfaces by default

### DIFF
--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -60,7 +60,8 @@ struct ServeCommand {
         long,
         value_name = "HOST IP",
         env = "HASURA_CONNECTOR_HOST",
-        default_value_t = net::IpAddr::V4(net::Ipv4Addr::UNSPECIFIED),
+        // listen on "::" defaulting to all IPv4 and IPv6 addresses
+        default_value_t = net::IpAddr::V6(net::Ipv6Addr::UNSPECIFIED),
     )]
     host: net::IpAddr,
     #[arg(


### PR DESCRIPTION
connectors started using ndc sdk currently only listens on ipv4 interfaces alone. this pr changes the default value to `net::IpAddr::V6(net::Ipv6Addr::UNSPECIFIED)` which translates to `::` which would then make the server listen on all ipv4 and ipv6 interfaces