### PR TITLE
Replace the health check with a readiness check.

### DIFF
--- a/crates/sdk/src/connector.rs
+++ b/crates/sdk/src/connector.rs
@@ -38,7 +38,7 @@ pub use error::*;
 /// a connection string would be configuration, but a connection pool object
 /// created from that connection string would be state.
 #[async_trait]
-pub trait Connector {
+pub trait Connector: Send {
     /// The type of validated configuration
     type Configuration: Sync + Send;
     /// The type of unserializable state
@@ -55,9 +55,16 @@ pub trait Connector {
 
     /// Check the health of the connector.
     ///
-    /// For example, this function should check that the connector
-    /// is able to reach its data source over the network.
-    async fn health_check(configuration: &Self::Configuration, state: &Self::State) -> Result<()>;
+    /// This should simply verify that the connector is ready to start accepting
+    /// requests. It should not verify that external data sources are available.
+    ///
+    /// For most use cases, the default implementation should be fine.
+    async fn get_health_readiness(
+        _configuration: &Self::Configuration,
+        _state: &Self::State,
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /// Get the connector's capabilities.
     ///

--- a/crates/sdk/src/connector/example.rs
+++ b/crates/sdk/src/connector/example.rs
@@ -38,13 +38,6 @@ impl Connector for Example {
         Ok(())
     }
 
-    async fn health_check(
-        _configuration: &Self::Configuration,
-        _state: &Self::State,
-    ) -> Result<()> {
-        Ok(())
-    }
-
     async fn get_capabilities() -> models::Capabilities {
         models::Capabilities {
             relationships: None,


### PR DESCRIPTION
The NDC specification states that the health check should respond with `200 OK` when the connector is ready to start accepting requests (i.e. "readiness").

Whether the underlying data source is up and running is not important here.

This adds a default implementation to the method to make it trivial for connector authors to handle this particular request. The method name has been changed to clarify matters and also to force connector authors to understand the change.

We will consider adding further endpoints to check "liveness" and "connectedness" in the future.