### PR TITLE
Add a request size limit

### DIFF
--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -46,7 +46,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0.115", features = ["raw_value"] }
 thiserror = "1.0"
 tokio = { version = "1.36.0", features = ["fs", "macros", "rt-multi-thread", "signal"] }
-tower-http = { version = "0.4.4", features = ["cors", "trace", "validate-request"] }
+tower-http = { version = "0.4.4", features = ["cors", "limit", "trace", "validate-request"] }
 tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "fmt", "json"] }

--- a/crates/sdk/src/connector/example.rs
+++ b/crates/sdk/src/connector/example.rs
@@ -126,7 +126,7 @@ mod tests {
     async fn capabilities_match_ndc_spec_version() -> Result<()> {
         let state =
             crate::default_main::init_server_state(Example::default(), PathBuf::new()).await?;
-        let app = crate::default_main::create_router::<Example>(state, None);
+        let app = crate::default_main::create_router::<Example>(state, None, None);
 
         let client = TestClient::new(app);
         let response = client.get("/capabilities").send().await;

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use axum::{
     body::Body,
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::{HeaderValue, Request, StatusCode},
     response::IntoResponse as _,
     routing::{get, post},
@@ -25,6 +25,9 @@ use crate::fetch_metrics::fetch_metrics;
 use crate::json_rejection::JsonRejection;
 use crate::json_response::JsonResponse;
 use crate::tracing::{init_tracing, make_span, on_response};
+
+// To add a limit to request sizes.
+const MB: usize = 1_048_576;
 
 #[derive(Parser)]
 struct CliArgs {
@@ -315,6 +318,7 @@ where
         )))
         .route("/health", get(get_health_readiness::<C>)) // health checks are not authenticated
         .with_state(state)
+        .layer(DefaultBodyLimit::max(100 * MB))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_span)

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -319,10 +319,7 @@ where
         // We want to limit the size of requests to 100MB to prevent various DDoS / SQL overflow
         // vulnerabilities. We use RequestBodyLimit instead of DefaultBodyLimit to include chunked
         // requests, too.
-        .layer(RequestBodyLimitLayer::new(match max_request_size {
-            Some(size) => size,
-            None => 100 * 1024 * 1024,
-        }))
+        .layer(RequestBodyLimitLayer::new(max_request_size.unwrap_or(100 * 1024 * 1024)))
         .layer(ValidateRequestHeaderLayer::custom(auth_handler(
             service_token_secret,
         )))

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -312,7 +312,12 @@ where
         .route("/query/explain", post(post_query_explain::<C>))
         .route("/mutation", post(post_mutation::<C>))
         .route("/mutation/explain", post(post_mutation_explain::<C>))
+
+        // We want to limit the size of requests to 100MB to prevent various DDoS / SQL overflow
+        // vulnerabilities. We use RequestBodyLimit instead of DefaultBodyLimit to include chunked
+        // requests, too.
         .layer(RequestBodyLimitLayer::new(100 * 1024 * 1024))
+
         .layer(ValidateRequestHeaderLayer::custom(auth_handler(
             service_token_secret,
         )))

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use axum::{
     body::Body,
-    extract::{DefaultBodyLimit, State},
+    extract::{RequestBodyLimit, State},
     http::{HeaderValue, Request, StatusCode},
     response::IntoResponse as _,
     routing::{get, post},
@@ -318,7 +318,7 @@ where
         )))
         .route("/health", get(get_health_readiness::<C>)) // health checks are not authenticated
         .with_state(state)
-        .layer(DefaultBodyLimit::max(100 * MB))
+        .layer(RequestBodyLimit::max(100 * MB))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_span)

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -319,7 +319,9 @@ where
         // We want to limit the size of requests to 100MB to prevent various DDoS / SQL overflow
         // vulnerabilities. We use RequestBodyLimit instead of DefaultBodyLimit to include chunked
         // requests, too.
-        .layer(RequestBodyLimitLayer::new(max_request_size.unwrap_or(100 * 1024 * 1024)))
+        .layer(RequestBodyLimitLayer::new(
+            max_request_size.unwrap_or(100 * 1024 * 1024),
+        ))
         .layer(ValidateRequestHeaderLayer::custom(auth_handler(
             service_token_secret,
         )))


### PR DESCRIPTION
There is a current issue in `sqlx` being investigated: https://github.com/launchbadge/sqlx/issues/3440

In Engine, we already have request size limits so this isn't an issue, but no such limits exist in the connectors. This PR adds a 100MB limit to connector requests, in order to avoid problems if bad actors find ways to query NDCs directly.