### PR TITLE
Initialize state on first request.

### DIFF
--- a/crates/sdk/src/connector.rs
+++ b/crates/sdk/src/connector.rs
@@ -147,7 +147,7 @@ pub trait ConnectorSetup:
         State = <Self::Connector as Connector>::State,
     > + 'static
 {
-    type Connector: Connector<Configuration: Clone, State: Clone> + 'static;
+    type Connector: Connector;
 }
 
 #[async_trait]

--- a/crates/sdk/src/connector/example.rs
+++ b/crates/sdk/src/connector/example.rs
@@ -10,8 +10,8 @@ use super::*;
 pub struct Example {}
 
 #[async_trait]
-impl ConnectorSetup for Example {
-    type Connector = Self;
+impl ParseConfiguration for Example {
+    type Configuration = ();
 
     async fn parse_configuration(
         &self,
@@ -19,6 +19,12 @@ impl ConnectorSetup for Example {
     ) -> Result<<Self as Connector>::Configuration> {
         Ok(())
     }
+}
+
+#[async_trait]
+impl InitState for Example {
+    type Configuration = ();
+    type State = ();
 
     async fn try_init_state(
         &self,
@@ -27,6 +33,11 @@ impl ConnectorSetup for Example {
     ) -> Result<<Self as Connector>::State> {
         Ok(())
     }
+}
+
+#[async_trait]
+impl ConnectorSetup for Example {
+    type Connector = Self;
 }
 
 #[async_trait]

--- a/crates/sdk/src/connector/example.rs
+++ b/crates/sdk/src/connector/example.rs
@@ -10,21 +10,15 @@ use super::*;
 pub struct Example {}
 
 #[async_trait]
-impl ParseConfiguration for Example {
-    type Configuration = ();
+impl ConnectorSetup for Example {
+    type Connector = Self;
 
     async fn parse_configuration(
         &self,
-        _configuration_dir: impl AsRef<Path> + Send,
+        _configuration_dir: &Path,
     ) -> Result<<Self as Connector>::Configuration> {
         Ok(())
     }
-}
-
-#[async_trait]
-impl InitState for Example {
-    type Configuration = ();
-    type State = ();
 
     async fn try_init_state(
         &self,
@@ -33,11 +27,6 @@ impl InitState for Example {
     ) -> Result<<Self as Connector>::State> {
         Ok(())
     }
-}
-
-#[async_trait]
-impl ConnectorSetup for Example {
-    type Connector = Self;
 }
 
 #[async_trait]
@@ -136,7 +125,7 @@ mod tests {
     #[tokio::test]
     async fn capabilities_match_ndc_spec_version() -> Result<()> {
         let state =
-            crate::default_main::init_server_state(Example::default(), PathBuf::new()).await?;
+            crate::default_main::init_server_state(Example::default(), &PathBuf::new()).await?;
         let app = crate::default_main::create_router::<Example>(state, None, None);
 
         let client = TestClient::new(app);

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -211,7 +211,7 @@ where
     )
     .expect("Unable to initialize tracing");
 
-    let server_state = init_server_state(setup, serve_command.configuration).await?;
+    let server_state = init_server_state(setup, &serve_command.configuration).await?;
 
     let router = create_router::<Setup::Connector>(
         server_state,
@@ -260,7 +260,7 @@ where
 /// Initialize the server state from the configuration file.
 pub async fn init_server_state<Setup: ConnectorSetup>(
     setup: Setup,
-    config_directory: impl AsRef<Path> + Send,
+    config_directory: &Path,
 ) -> Result<ServerState<Setup::Connector>> {
     let metrics = Registry::new();
     let configuration = setup.parse_configuration(config_directory).await?;
@@ -458,7 +458,7 @@ mod ndc_test_commands {
         }
     }
 
-    pub(super) async fn test<Setup: super::ConnectorSetup>(
+    pub(super) async fn test<Setup: ConnectorSetup>(
         setup: Setup,
         command: super::TestCommand,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -486,7 +486,7 @@ mod ndc_test_commands {
         Ok(())
     }
 
-    pub(super) async fn replay<Setup: super::ConnectorSetup>(
+    pub(super) async fn replay<Setup: ConnectorSetup>(
         setup: Setup,
         command: super::ReplayCommand,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -550,7 +550,7 @@ mod ndc_test_commands {
         configuration_path: PathBuf,
     ) -> Result<ConnectorAdapter<Setup::Connector>, Box<dyn Error + Send + Sync>> {
         let mut metrics = Registry::new();
-        let configuration = setup.parse_configuration(configuration_path).await?;
+        let configuration = setup.parse_configuration(&configuration_path).await?;
         let state = setup.try_init_state(&configuration, &mut metrics).await?;
         Ok(ConnectorAdapter {
             configuration,

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -355,7 +355,7 @@ fn auth_handler(
 }
 
 async fn get_metrics<C: Connector>(State(state): State<ServerState<C>>) -> Result<String> {
-    fetch_metrics::<C>(&state.configuration, &state.state, &state.metrics)
+    fetch_metrics::<C>(state.configuration(), state.state(), state.metrics())
 }
 
 async fn get_capabilities<C: Connector>() -> JsonResponse<CapabilitiesResponse> {
@@ -368,41 +368,41 @@ async fn get_capabilities<C: Connector>() -> JsonResponse<CapabilitiesResponse> 
 }
 
 async fn get_health_readiness<C: Connector>(State(state): State<ServerState<C>>) -> Result<()> {
-    C::get_health_readiness(&state.configuration, &state.state).await
+    C::get_health_readiness(state.configuration(), state.state()).await
 }
 
 async fn get_schema<C: Connector>(
     State(state): State<ServerState<C>>,
 ) -> Result<JsonResponse<SchemaResponse>> {
-    C::get_schema(&state.configuration).await
+    C::get_schema(state.configuration()).await
 }
 
 async fn post_query_explain<C: Connector>(
     State(state): State<ServerState<C>>,
     WithRejection(Json(request), _): WithRejection<Json<QueryRequest>, JsonRejection>,
 ) -> Result<JsonResponse<ExplainResponse>> {
-    C::query_explain(&state.configuration, &state.state, request).await
+    C::query_explain(state.configuration(), state.state(), request).await
 }
 
 async fn post_mutation_explain<C: Connector>(
     State(state): State<ServerState<C>>,
     WithRejection(Json(request), _): WithRejection<Json<MutationRequest>, JsonRejection>,
 ) -> Result<JsonResponse<ExplainResponse>> {
-    C::mutation_explain(&state.configuration, &state.state, request).await
+    C::mutation_explain(state.configuration(), state.state(), request).await
 }
 
 async fn post_mutation<C: Connector>(
     State(state): State<ServerState<C>>,
     WithRejection(Json(request), _): WithRejection<Json<MutationRequest>, JsonRejection>,
 ) -> Result<JsonResponse<MutationResponse>> {
-    C::mutation(&state.configuration, &state.state, request).await
+    C::mutation(state.configuration(), state.state(), request).await
 }
 
 async fn post_query<C: Connector>(
     State(state): State<ServerState<C>>,
     WithRejection(Json(request), _): WithRejection<Json<QueryRequest>, JsonRejection>,
 ) -> Result<JsonResponse<QueryResponse>> {
-    C::query(&state.configuration, &state.state, request).await
+    C::query(state.configuration(), state.state(), request).await
 }
 
 #[cfg(feature = "ndc-test")]

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -26,6 +26,7 @@ use crate::connector::{Connector, ConnectorSetup, ErrorResponse, Result};
 use crate::fetch_metrics::fetch_metrics;
 use crate::json_rejection::JsonRejection;
 use crate::json_response::JsonResponse;
+use crate::state::ServerState;
 use crate::tracing::{init_tracing, make_span, on_response};
 
 #[derive(Parser)]
@@ -137,37 +138,6 @@ struct CheckHealthCommand {
 }
 
 type Port = u16;
-
-#[derive(Debug)]
-pub struct ServerState<C: Connector> {
-    configuration: C::Configuration,
-    state: C::State,
-    metrics: Registry,
-}
-
-impl<C: Connector> Clone for ServerState<C>
-where
-    C::Configuration: Clone,
-    C::State: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            configuration: self.configuration.clone(),
-            state: self.state.clone(),
-            metrics: self.metrics.clone(),
-        }
-    }
-}
-
-impl<C: Connector> ServerState<C> {
-    pub fn new(configuration: C::Configuration, state: C::State, metrics: Registry) -> Self {
-        Self {
-            configuration,
-            state,
-            metrics,
-        }
-    }
-}
 
 /// A default main function for a connector.
 ///

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -214,8 +214,8 @@ where
     let server_state = init_server_state(setup, serve_command.configuration).await?;
 
     let router = create_router::<Setup::Connector>(
-        server_state.clone(),
-        serve_command.service_token_secret.clone(),
+        server_state,
+        serve_command.service_token_secret,
         serve_command.max_request_size,
     );
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -4,6 +4,7 @@ pub mod default_main;
 pub mod fetch_metrics;
 pub mod json_rejection;
 pub mod json_response;
+pub mod state;
 pub mod tracing;
 
 pub use ndc_models as models;

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -1,0 +1,36 @@
+use crate::connector::Connector;
+
+#[derive(Debug)]
+pub struct ServerState<C: Connector> {
+    pub configuration: C::Configuration,
+    pub state: C::State,
+    pub metrics: prometheus::Registry,
+}
+
+impl<C: Connector> Clone for ServerState<C>
+where
+    C::Configuration: Clone,
+    C::State: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            configuration: self.configuration.clone(),
+            state: self.state.clone(),
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+impl<C: Connector> ServerState<C> {
+    pub fn new(
+        configuration: C::Configuration,
+        state: C::State,
+        metrics: prometheus::Registry,
+    ) -> Self {
+        Self {
+            configuration,
+            state,
+            metrics,
+        }
+    }
+}

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 use crate::connector::error::*;
-use crate::connector::{Connector, InitState};
+use crate::connector::{Connector, ConnectorSetup};
 
 /// Everything we need to keep in memory.
 pub struct ServerState<C: Connector> {
@@ -15,7 +15,7 @@ pub struct ServerState<C: Connector> {
 /// The connector state, which may or may not be initialized.
 struct ConnectorState<C: Connector> {
     cell: OnceCell<C::State>,
-    init_state: Box<dyn InitState<Configuration = C::Configuration, State = C::State>>,
+    init_state: Box<dyn ConnectorSetup<Connector = C>>,
 }
 
 // Server state must be cloneable even if the underlying connector is not.
@@ -39,7 +39,7 @@ impl<C: Connector> ServerState<C> {
     /// Construct a new server state.
     pub fn new(
         configuration: C::Configuration,
-        init_state: impl InitState<Configuration = C::Configuration, State = C::State> + 'static,
+        init_state: impl ConnectorSetup<Connector = C> + 'static,
         metrics: prometheus::Registry,
     ) -> Self {
         Self {

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -2,9 +2,9 @@ use crate::connector::Connector;
 
 #[derive(Debug)]
 pub struct ServerState<C: Connector> {
-    pub configuration: C::Configuration,
-    pub state: C::State,
-    pub metrics: prometheus::Registry,
+    configuration: C::Configuration,
+    state: C::State,
+    metrics: prometheus::Registry,
 }
 
 impl<C: Connector> Clone for ServerState<C>
@@ -32,5 +32,17 @@ impl<C: Connector> ServerState<C> {
             state,
             metrics,
         }
+    }
+
+    pub fn configuration(&self) -> &C::Configuration {
+        &self.configuration
+    }
+
+    pub fn state(&self) -> &C::State {
+        &self.state
+    }
+
+    pub fn metrics(&self) -> &prometheus::Registry {
+        &self.metrics
     }
 }

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -1,16 +1,30 @@
-use crate::connector::Connector;
+use std::sync::Arc;
 
-#[derive(Debug)]
+use tokio::sync::OnceCell;
+
+use crate::connector::error::*;
+use crate::connector::{Connector, InitState};
+
+/// Everything we need to keep in memory.
 pub struct ServerState<C: Connector> {
     configuration: C::Configuration,
-    state: C::State,
+    state: Arc<ApplicationState<C>>,
     metrics: prometheus::Registry,
 }
 
+/// The application state, which may or may not be initialized.
+struct ApplicationState<C: Connector> {
+    cell: OnceCell<C::State>,
+    init_state: Box<dyn InitState<Configuration = C::Configuration, State = C::State>>,
+}
+
+// Server state must be cloneable even if the underlying connector is not.
+// We only require `Connector::Configuration` to be cloneable.
+//
+// Server state is always stored in an `Arc`, so is therefore cloneable.
 impl<C: Connector> Clone for ServerState<C>
 where
     C::Configuration: Clone,
-    C::State: Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -22,26 +36,45 @@ where
 }
 
 impl<C: Connector> ServerState<C> {
+    /// Construct a new server state.
     pub fn new(
         configuration: C::Configuration,
-        state: C::State,
+        init_state: impl InitState<Configuration = C::Configuration, State = C::State> + 'static,
         metrics: prometheus::Registry,
     ) -> Self {
         Self {
             configuration,
-            state,
+            state: Arc::new(ApplicationState {
+                cell: OnceCell::new(),
+                init_state: Box::new(init_state),
+            }),
             metrics,
         }
     }
 
+    /// The server configuration.
     pub fn configuration(&self) -> &C::Configuration {
         &self.configuration
     }
 
-    pub fn state(&self) -> &C::State {
-        &self.state
+    /// The transient server state.
+    ///
+    /// If the state has not yet been initialized, this initializes it.
+    ///
+    /// On initialization failure, this function will also fail, and subsequent calls will retry.
+    pub async fn state(&self) -> Result<&C::State> {
+        self.state
+            .cell
+            .get_or_try_init(|| async {
+                self.state
+                    .init_state
+                    .try_init_state(&self.configuration, &mut self.metrics.clone())
+                    .await
+            })
+            .await
     }
 
+    /// The server metrics.
     pub fn metrics(&self) -> &prometheus::Registry {
         &self.metrics
     }

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -8,12 +8,12 @@ use crate::connector::{Connector, InitState};
 /// Everything we need to keep in memory.
 pub struct ServerState<C: Connector> {
     configuration: C::Configuration,
-    state: Arc<ApplicationState<C>>,
+    state: Arc<ConnectorState<C>>,
     metrics: prometheus::Registry,
 }
 
-/// The application state, which may or may not be initialized.
-struct ApplicationState<C: Connector> {
+/// The connector state, which may or may not be initialized.
+struct ConnectorState<C: Connector> {
     cell: OnceCell<C::State>,
     init_state: Box<dyn InitState<Configuration = C::Configuration, State = C::State>>,
 }
@@ -44,7 +44,7 @@ impl<C: Connector> ServerState<C> {
     ) -> Self {
         Self {
             configuration,
-            state: Arc::new(ApplicationState {
+            state: Arc::new(ConnectorState {
                 cell: OnceCell::new(),
                 init_state: Box::new(init_state),
             }),


### PR DESCRIPTION
We don't need state to successfully handle some requests, so let's not initialize it until we need it.

With these changes, requests to `/capabilities`, `/schema`, and `/health` will still succeed even if the state cannot be initialized.

This wraps the state in a `OnceCell` which is initialized on first use.

This changes the `ConnectorSetup` interface, and as such constitutes a breaking change.