### PR TITLE
Inline axum-test-helper.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,24 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-test-helper"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298f62fa902c2515c169ab0bfb56c593229f33faa01131215d58e3d4898e3aa9"
-dependencies = [
- "axum",
- "bytes",
- "http",
- "http-body",
- "hyper",
- "reqwest",
- "serde",
- "tokio",
- "tower",
- "tower-service",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,10 +982,10 @@ dependencies = [
 name = "ndc-sdk"
 version = "0.4.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "axum",
  "axum-extra",
- "axum-test-helper",
  "bytes",
  "clap",
  "http",
@@ -1540,12 +1522,10 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -2504,19 +2484,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "web-sys"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -53,4 +53,4 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["a
 url = "2"
 
 [dev-dependencies]
-axum-test-helper = "0.3"
+anyhow = "1"

--- a/crates/sdk/src/connector/example.rs
+++ b/crates/sdk/src/connector/example.rs
@@ -112,29 +112,3 @@ impl Connector for Example {
         todo!()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-
-    use axum_test_helper::TestClient;
-    use http::StatusCode;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn capabilities_match_ndc_spec_version() -> Result<()> {
-        let state =
-            crate::default_main::init_server_state(Example::default(), &PathBuf::new()).await?;
-        let app = crate::default_main::create_router::<Example>(state, None, None);
-
-        let client = TestClient::new(app);
-        let response = client.get("/capabilities").send().await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body: ndc_models::CapabilitiesResponse = response.json().await;
-        assert_eq!(body.version, ndc_models::VERSION);
-        Ok(())
-    }
-}


### PR DESCRIPTION
Its dependency tree does not agree with us.

We can simply reproduce the [`TestClient`][test_client.rs] from the internals of `axum` ourselves (which is what `axum-test-helper` does, too).

Our version has even fewer features, because we only need to support `GET` requests.

[test_client.rs]: https://github.com/tokio-rs/axum/blob/axum-v0.6.20/axum/src/test_helpers/test_client.rs