### PR TITLE
Fix: Correct command to run example connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cargo build
 
 ```sh
 mkdir empty
-cargo run --bin ndc_hub_example -- --configuration ./empty
+cargo run --bin ndc_hub_example serve --configuration ./empty
 ```
 
 Inspect the resulting (empty) schema:


### PR DESCRIPTION
The README currently provides an incorrect command to run the `ndc_hub_example` connector. This PR updates the command to use the `serve` subcommand and the `--configuration` flag, which are required according to the output of `cargo run --bin ndc_hub_example serve --help`.

**Changes:**

- Updated the "Run the example connector" section in the README to use the correct command:
  ```sh
  cargo run --bin ndc_hub_example serve --configuration ./empty