### PR TITLE
Update to NDC Spec v0.2.0 final, bump version to v0.6.0

### DIFF
--- a/.github/workflows/machete.yaml
+++ b/.github/workflows/machete.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: install tools
         run: |
           rustup show
-          cargo install cargo-machete
+          cargo install cargo-machete@0.7.0 # version 0.8.0 requires Rust 1.85.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming release
 
-**Breaking changes** ([#38](https://github.com/hasura/ndc-sdk-rs/pull/38), [#40](https://github.com/hasura/ndc-sdk-rs/pull/40), [#41](https://github.com/hasura/ndc-sdk-rs/pull/41)):
+## [0.6.0]
+
+**Breaking changes** ([#38](https://github.com/hasura/ndc-sdk-rs/pull/38), [#40](https://github.com/hasura/ndc-sdk-rs/pull/40), [#41](https://github.com/hasura/ndc-sdk-rs/pull/41), [#42](https://github.com/hasura/ndc-sdk-rs/pull/42)):
 
 - Updated to support [v0.2.0 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#020). This is a very large update which adds new features and some breaking changes.
 - If the [`X-Hasura-NDC-Version`](https://hasura.github.io/ndc-spec/specification/versioning.html) header is sent, the SDK will validate that the connector supports the incoming request's version and reject it if it does not. If no header is sent, no action is taken.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "ndc-models"
 version = "0.2.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0-rc.3#9c202b92fd72be93b6a180f6b8dbf70607eca7b4"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0#e25213f51a7e8422d712509d63ae012c67b4f3f1"
 dependencies = [
  "indexmap 2.7.1",
  "ref-cast",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "ndc-sdk-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "ndc-test"
 version = "0.2.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0-rc.3#9c202b92fd72be93b6a180f6b8dbf70607eca7b4"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0#e25213f51a7e8422d712509d63ae012c67b4f3f1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1318,9 +1318,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.69"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -1350,9 +1350,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -1816,15 +1816,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2178,12 +2177,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-package.version = "0.5.0"
+package.version = "0.6.0"
 package.edition = "2021"
 package.license = "Apache-2.0"
 
@@ -9,8 +9,8 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 ndc-sdk-core = { path = "../sdk-core" }
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0-rc.3" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0-rc.3" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0" }
 
 anyhow = "1"
 async-trait = "0.1"


### PR DESCRIPTION
Updates the NDC Spec to the final v0.2.0 release version, and bumps the version of the package to v0.6.0.

Also pins the version of cargo machete used in CI so that it is compatible with the Rust version used here.