### PR TITLE
Include connector name and version in traces

### DIFF
--- a/crates/sdk-core/src/connector.rs
+++ b/crates/sdk-core/src/connector.rs
@@ -44,9 +44,9 @@ pub trait Connector: Send + 'static {
     /// The type of unserializable state
     type State: Send + Sync;
 
-    fn connector_name() -> String;
+    fn connector_name() -> &'static str;
 
-    fn connector_version() -> String;
+    fn connector_version() -> &'static str;
 
     /// Update any metrics from the state
     ///

--- a/crates/sdk-core/src/connector.rs
+++ b/crates/sdk-core/src/connector.rs
@@ -44,6 +44,10 @@ pub trait Connector: Send + 'static {
     /// The type of unserializable state
     type State: Send + Sync;
 
+    fn connector_name() -> String;
+
+    fn connector_version() -> String;
+
     /// Update any metrics from the state
     ///
     /// Note: some metrics can be updated directly, and do not

--- a/crates/sdk-core/src/connector/example.rs
+++ b/crates/sdk-core/src/connector/example.rs
@@ -34,6 +34,14 @@ impl Connector for Example {
     type Configuration = ();
     type State = ();
 
+    fn connector_name() -> String {
+        "example".into()
+    }
+
+    fn connector_version() -> String {
+        "1.0.0".into()
+    }
+
     fn fetch_metrics(_configuration: &Self::Configuration, _state: &Self::State) -> Result<()> {
         Ok(())
     }

--- a/crates/sdk-core/src/connector/example.rs
+++ b/crates/sdk-core/src/connector/example.rs
@@ -34,12 +34,12 @@ impl Connector for Example {
     type Configuration = ();
     type State = ();
 
-    fn connector_name() -> String {
-        "example".into()
+    fn connector_name() -> &'static str {
+        "example"
     }
 
-    fn connector_version() -> String {
-        "1.0.0".into()
+    fn connector_version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
     }
 
     fn fetch_metrics(_configuration: &Self::Configuration, _state: &Self::State) -> Result<()> {

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -82,6 +82,14 @@ struct ServeCommand {
     service_name: Option<String>,
     #[arg(long, value_name = "MAX_REQUEST_SIZE", env = "HASURA_MAX_REQUEST_SIZE")]
     max_request_size: Option<usize>,
+    #[arg(long, value_name = "CONNECTOR_NAME", env = "HASURA_CONNECTOR_NAME")]
+    connector_name: Option<String>,
+    #[arg(
+        long,
+        value_name = "CONNECTOR_VERSION",
+        env = "HASURA_CONNECTOR_VERSION"
+    )]
+    connector_version: Option<String>,
 }
 
 #[derive(Clone, Parser)]
@@ -221,6 +229,8 @@ where
     init_tracing(
         serve_command.service_name.as_deref(),
         serve_command.otlp_endpoint.as_deref(),
+        serve_command.connector_name.as_deref(),
+        serve_command.connector_version.as_deref(),
     )
     .expect("Unable to initialize tracing");
 

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -82,14 +82,6 @@ struct ServeCommand {
     service_name: Option<String>,
     #[arg(long, value_name = "MAX_REQUEST_SIZE", env = "HASURA_MAX_REQUEST_SIZE")]
     max_request_size: Option<usize>,
-    #[arg(long, value_name = "CONNECTOR_NAME", env = "HASURA_CONNECTOR_NAME")]
-    connector_name: Option<String>,
-    #[arg(
-        long,
-        value_name = "CONNECTOR_VERSION",
-        env = "HASURA_CONNECTOR_VERSION"
-    )]
-    connector_version: Option<String>,
 }
 
 #[derive(Clone, Parser)]
@@ -229,8 +221,8 @@ where
     init_tracing(
         serve_command.service_name.as_deref(),
         serve_command.otlp_endpoint.as_deref(),
-        serve_command.connector_name.as_deref(),
-        serve_command.connector_version.as_deref(),
+        <Setup::Connector as Connector>::connector_name(),
+        <Setup::Connector as Connector>::connector_version(),
     )
     .expect("Unable to initialize tracing");
 

--- a/crates/sdk/src/tracing.rs
+++ b/crates/sdk/src/tracing.rs
@@ -11,9 +11,14 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+static CONNECTOR_NAME: &str = "service.connector.name";
+static CONNECTOR_VERSION: &str = "service.connector.version";
+
 pub fn init_tracing(
     service_name: Option<&str>,
     otlp_endpoint: Option<&str>,
+    connector_name: Option<&str>,
+    connector_version: Option<&str>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let trace_endpoint = otlp_endpoint
         .map(ToOwned::to_owned)
@@ -67,21 +72,39 @@ pub fn init_tracing(
                     }
                 }?;
 
+            let mut resources = vec![
+                opentelemetry::KeyValue::new(
+                    opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                    service_name.to_string(),
+                ),
+                opentelemetry::KeyValue::new(
+                    opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
+                    env!("CARGO_PKG_VERSION"),
+                ),
+            ];
+
+            if let Some(connector_name) = connector_name {
+                resources.push(opentelemetry::KeyValue::new(
+                    CONNECTOR_NAME,
+                    connector_name.to_string(),
+                ));
+            } else if let Ok(binary_name) = std::env::var("CARGO_BIN_NAME") {
+                resources.push(opentelemetry::KeyValue::new(CONNECTOR_NAME, binary_name));
+            }
+
+            if let Some(connector_version) = connector_version {
+                resources.push(opentelemetry::KeyValue::new(
+                    CONNECTOR_VERSION,
+                    connector_version.to_string(),
+                ));
+            }
+
             let tracer = opentelemetry_otlp::new_pipeline()
                 .tracing()
                 .with_exporter(exporter)
                 .with_trace_config(
                     opentelemetry_sdk::trace::config()
-                        .with_resource(opentelemetry_sdk::Resource::new(vec![
-                            opentelemetry::KeyValue::new(
-                                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
-                                service_name.to_string(),
-                            ),
-                            opentelemetry::KeyValue::new(
-                                opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
-                                env!("CARGO_PKG_VERSION"),
-                            ),
-                        ]))
+                        .with_resource(opentelemetry_sdk::Resource::new(resources))
                         .with_sampler(opentelemetry_sdk::trace::Sampler::ParentBased(Box::new(
                             opentelemetry_sdk::trace::Sampler::AlwaysOn,
                         ))),

--- a/crates/sdk/src/tracing.rs
+++ b/crates/sdk/src/tracing.rs
@@ -17,8 +17,8 @@ static CONNECTOR_VERSION: &str = "service.connector.version";
 pub fn init_tracing(
     service_name: Option<&str>,
     otlp_endpoint: Option<&str>,
-    connector_name: String,
-    connector_version: String,
+    connector_name: &str,
+    connector_version: &str,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let trace_endpoint = otlp_endpoint
         .map(ToOwned::to_owned)


### PR DESCRIPTION
We want to report on these, so let's include them in a standardised way. We add `connector_name()` and `connector_version()` functions to the `Connector` trait.