### PR TITLE
Add relational query endpoints to the SDK

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v20
+        uses: DeterminateSystems/nix-installer-action@v21
 
       - name: Run the Magic Nix Cache 🔌
         uses: DeterminateSystems/magic-nix-cache-action@v13
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v20
+        uses: DeterminateSystems/nix-installer-action@v21
 
       - name: Run the Magic Nix Cache 🔌
         uses: DeterminateSystems/magic-nix-cache-action@v13
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v20
+        uses: DeterminateSystems/nix-installer-action@v21
 
       - name: Run the Magic Nix Cache 🔌
         uses: DeterminateSystems/magic-nix-cache-action@v13
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v20
+        uses: DeterminateSystems/nix-installer-action@v21
 
       - name: Run the Magic Nix Cache 🔌
         uses: DeterminateSystems/magic-nix-cache-action@v13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,10 +158,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "axum"
-version = "0.8.4"
+name = "aws-lc-rs"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
@@ -178,8 +200,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -193,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -204,7 +225,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -213,24 +233,23 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+checksum = "fef252edff26ddba56bbcdf2ee3307b8129acb86f5749b68990c168a6fcc9c76"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
- "serde",
- "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -245,7 +264,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -280,14 +299,21 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -311,7 +337,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -355,6 +381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +400,16 @@ name = "colorful"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97af0562545a7d7f3d9222fcf909963bec36dcb502afaacab98c6ffac8da47ce"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -464,6 +509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,15 +525,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "equivalent"
@@ -505,6 +547,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -545,6 +593,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -643,7 +697,7 @@ dependencies = [
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -743,13 +797,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -757,6 +812,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -776,7 +832,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -810,18 +865,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1035,6 +1094,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1123,28 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -1122,11 +1213,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1196,8 +1287,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.2.12"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.12#86af33d8a09228a74499d02a1f838bf9f7a9759f"
+version = "0.2.11"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.11#c28e719754e55a7c086e0cc2682dabd97d9b405f"
 dependencies = [
  "indexmap 2.7.1",
  "ref-cast",
@@ -1228,10 +1319,10 @@ dependencies = [
  "opentelemetry-zipkin",
  "opentelemetry_sdk",
  "prometheus",
- "reqwest",
+ "reqwest 0.13.2",
  "semver",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tokio",
  "tower-http",
  "tracing",
@@ -1254,20 +1345,19 @@ dependencies = [
  "ndc-models",
  "ndc-test",
  "prometheus",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tokio",
- "tokio-stream",
  "tokio-test",
  "tracing",
 ]
 
 [[package]]
 name = "ndc-test"
-version = "0.2.12"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.12#86af33d8a09228a74499d02a1f838bf9f7a9759f"
+version = "0.2.11"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.11#c28e719754e55a7c086e0cc2682dabd97d9b405f"
 dependencies = [
  "async-trait",
  "clap",
@@ -1276,7 +1366,7 @@ dependencies = [
  "ndc-models",
  "pretty_assertions",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.12",
  "semver",
  "serde",
  "serde_json",
@@ -1287,12 +1377,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1371,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1385,22 +1474,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.12",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1408,7 +1497,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.12",
  "thiserror 2.0.16",
  "tokio",
  "tonic",
@@ -1417,34 +1506,35 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.16.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "opentelemetry-zipkin"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8823568a9abd4003d1acc564bcfec8e3406a8c73203f8f50bdfc88b44d7ecfb6"
+checksum = "f27fcd074586dab55936b003c6a499acaabd6debbd539c3f36356bca2ef2fce2"
 dependencies = [
  "http",
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
- "reqwest",
+ "reqwest 0.12.12",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -1453,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -1463,17 +1553,10 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "serde_json",
  "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1495,7 +1578,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1593,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1603,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1647,7 +1730,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -1660,6 +1743,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.1",
  "lru-slab",
@@ -1684,7 +1768,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1787,27 +1871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,14 +1878,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1836,19 +1893,15 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -1860,27 +1913,60 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pemfile",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.11",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -1928,6 +2014,7 @@ version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1968,11 +2055,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1989,6 +2104,15 @@ name = "ryu"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2076,18 +2200,28 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2220,16 +2354,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -2285,27 +2409,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2443,7 +2546,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -2518,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -2534,8 +2637,8 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
  "rustls-native-certs",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -2543,6 +2646,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -2566,21 +2680,24 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "bitflags",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "iri-string",
  "mime",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2600,9 +2717,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2612,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2644,14 +2761,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -2672,14 +2787,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -2773,6 +2888,16 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2890,44 +3015,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
+name = "webpki-root-certs"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "winapi-util"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2935,7 +3038,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2946,7 +3049,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2955,7 +3058,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2965,7 +3068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -2974,7 +3086,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2983,7 +3095,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2992,15 +3119,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3010,9 +3143,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3028,9 +3173,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3040,9 +3197,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,8 +1287,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.2.11"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.11#c28e719754e55a7c086e0cc2682dabd97d9b405f"
+version = "0.2.12"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.12#86af33d8a09228a74499d02a1f838bf9f7a9759f"
 dependencies = [
  "indexmap 2.7.1",
  "ref-cast",
@@ -1356,8 +1356,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-test"
-version = "0.2.11"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.11#c28e719754e55a7c086e0cc2682dabd97d9b405f"
+version = "0.2.12"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.12#86af33d8a09228a74499d02a1f838bf9f7a9759f"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,8 +1196,8 @@ dependencies = [
 
 [[package]]
 name = "ndc-models"
-version = "0.2.10"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.10#b8e165ce31d25abd84a6fcb41fc61190227654b8"
+version = "0.2.12"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.12#86af33d8a09228a74499d02a1f838bf9f7a9759f"
 dependencies = [
  "indexmap 2.7.1",
  "ref-cast",
@@ -1216,6 +1216,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "clap",
+ "futures-util",
  "http",
  "ndc-models",
  "ndc-sdk-core",
@@ -1247,6 +1248,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bytes",
+ "futures-util",
  "http",
  "mime",
  "ndc-models",
@@ -1257,14 +1259,15 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tokio-test",
  "tracing",
 ]
 
 [[package]]
 name = "ndc-test"
-version = "0.2.10"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.10#b8e165ce31d25abd84a6fcb41fc61190227654b8"
+version = "0.2.12"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.12#86af33d8a09228a74499d02a1f838bf9f7a9759f"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 ndc-sdk-core = { path = "../sdk-core" }
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.10" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.12" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.12" }
 
 anyhow = "1"
 async-trait = "0.1"
@@ -48,7 +48,9 @@ tokio = { version = "1", features = [
   "rt-multi-thread",
   "signal",
 ] }
+tokio-stream = "0.1"
 tokio-test = "0.4"
+futures-util = "0.3"
 tower-http = { version = "0.6", features = [
   "cors",
   "limit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 ndc-sdk-core = { path = "../sdk-core" }
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.11" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.11" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.12" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.12" }
 
 anyhow = "1"
 async-trait = "0.1"
@@ -37,7 +37,11 @@ prometheus = "0.14"
 # Adding the gzip/zstd features have the library send appropriate
 # Accept-Encoding and automatically decompress. As of this version it doesn't
 # express preference with quality (q) values, but we'd prefer zstd always
-reqwest = { version = "^0.13", default-features = false, features = ["gzip", "zstd", "json"] }
+reqwest = { version = "^0.13", default-features = false, features = [
+  "gzip",
+  "zstd",
+  "json",
+] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,20 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 ndc-sdk-core = { path = "../sdk-core" }
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.12" }
-ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.12" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.11" }
+ndc-test = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.11" }
 
 anyhow = "1"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
-axum-extra = "0.10"
+axum-extra = "0.12"
 bytes = "1"
 clap = { version = "4", features = ["derive", "env"] }
 http = "1"
 mime = "0.3"
-opentelemetry = "0.30"
-opentelemetry-http = "0.30"
-opentelemetry-otlp = { version = "0.30", features = [
+opentelemetry = "0.31"
+opentelemetry-http = "0.31"
+opentelemetry-otlp = { version = "0.31", features = [
   "reqwest-client",
   "grpc-tonic",
   "gzip-tonic",
@@ -30,25 +30,24 @@ opentelemetry-otlp = { version = "0.30", features = [
   "tls-roots",
   "http-proto",
 ] }
-opentelemetry-semantic-conventions = "0.16"
-opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
-opentelemetry-zipkin = "0.30"
+opentelemetry-semantic-conventions = "0.31"
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry-zipkin = "0.31"
 prometheus = "0.14"
 # Adding the gzip/zstd features have the library send appropriate
 # Accept-Encoding and automatically decompress. As of this version it doesn't
 # express preference with quality (q) values, but we'd prefer zstd always
-reqwest = { version = "0.12", features = ["gzip", "zstd", "json"] }
+reqwest = { version = "^0.13", default-features = false, features = ["gzip", "zstd", "json"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
-thiserror = "1"
+thiserror = "2"
 tokio = { version = "1", features = [
   "fs",
   "macros",
   "rt-multi-thread",
   "signal",
 ] }
-tokio-stream = "0.1"
 tokio-test = "0.4"
 futures-util = "0.3"
 tower-http = { version = "0.6", features = [
@@ -60,7 +59,7 @@ tower-http = { version = "0.6", features = [
   "compression-zstd",
 ] }
 tracing = "0.1"
-tracing-opentelemetry = "0.31"
+tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "ansi",
   "env-filter",

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -32,6 +32,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "signal", "sync"] }
+tokio-stream = { workspace = true }
+futures-util = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -32,7 +32,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "signal", "sync"] }
-tokio-stream = { workspace = true }
 futures-util = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/sdk-core/src/connector.rs
+++ b/crates/sdk-core/src/connector.rs
@@ -1,5 +1,6 @@
 use crate::json_response::JsonResponse;
 use async_trait::async_trait;
+use futures_util::stream::BoxStream;
 use ndc_models as models;
 use std::path::Path;
 pub mod error;
@@ -135,6 +136,37 @@ pub trait Connector: Send + 'static {
         state: &Self::State,
         request: models::QueryRequest,
     ) -> Result<JsonResponse<models::QueryResponse>>;
+
+    /// Execute a relational query
+    ///
+    /// This function implements the relational query endpoint from the NDC specification.
+    /// This is an experimental API and connectors are not required to implement it.
+    ///
+    /// The default implementation returns a "not supported" error.
+    async fn query_relational(
+        _configuration: &Self::Configuration,
+        _state: &Self::State,
+        _request: models::RelationalQuery,
+    ) -> Result<JsonResponse<models::RelationalQueryResponse>> {
+        Err(NotSupported::new().into())
+    }
+
+    /// Execute a relational query with streaming response
+    ///
+    /// This function implements the streaming relational query endpoint from the NDC specification.
+    /// It returns a stream of JSON values, where each value represents a row in the result set.
+    /// The HTTP layer will serialize each row as a newline-delimited JSON (NDJSON) line.
+    ///
+    /// This is an experimental API and connectors are not required to implement it.
+    ///
+    /// The default implementation returns a "not supported" error.
+    async fn query_relational_stream(
+        _configuration: &Self::Configuration,
+        _state: &Self::State,
+        _request: models::RelationalQuery,
+    ) -> Result<BoxStream<'static, Result<Vec<serde_json::Value>>>> {
+        Err(NotSupported::new().into())
+    }
 }
 
 /// Connectors are set up by values that implement this trait.

--- a/crates/sdk-core/src/connector/error.rs
+++ b/crates/sdk-core/src/connector/error.rs
@@ -393,3 +393,45 @@ impl From<MutationError> for ErrorResponse {
         }
     }
 }
+
+/// Error indicating that a feature is not supported by this connector.
+///
+/// This is used as the default return value for optional connector methods
+/// like relational queries.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("Not supported")]
+pub struct NotSupported {
+    message: String,
+}
+
+impl NotSupported {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            message: "This operation is not supported by this connector".to_string(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl Default for NotSupported {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<NotSupported> for ErrorResponse {
+    fn from(value: NotSupported) -> Self {
+        ErrorResponse::new(
+            StatusCode::NOT_IMPLEMENTED,
+            value.message,
+            serde_json::Value::Null,
+        )
+    }
+}

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -19,7 +19,7 @@ path = "bin/main.rs"
 default = ["native-tls", "ndc-test"]
 
 native-tls = ["reqwest/native-tls"]
-rustls = ["reqwest/rustls-tls"]
+rustls = ["reqwest/rustls"]
 
 ndc-test = ["dep:ndc-test", "ndc-sdk-core/ndc-test"]
 
@@ -30,7 +30,7 @@ ndc-test = { workspace = true, optional = true }
 
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["http2"] }
-axum-extra = { workspace = true }
+axum-extra = { workspace = true, features = ["with-rejection"] }
 clap = { workspace = true, features = ["derive", "env"] }
 http = { workspace = true }
 opentelemetry = { workspace = true }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -45,6 +45,7 @@ semver = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "signal"] }
+futures-util = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "limit", "trace", "validate-request"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }

--- a/crates/sdk/src/default_main.rs
+++ b/crates/sdk/src/default_main.rs
@@ -18,7 +18,8 @@ use tower_http::{
 };
 
 use ndc_models::{
-    ExplainResponse, MutationRequest, MutationResponse, QueryRequest, QueryResponse, SchemaResponse,
+    ExplainResponse, MutationRequest, MutationResponse, QueryRequest, QueryResponse,
+    RelationalQuery, RelationalQueryResponse, SchemaResponse,
 };
 
 use crate::check_health;
@@ -299,6 +300,11 @@ where
         .route("/query/explain", post(post_query_explain::<C>))
         .route("/mutation", post(post_mutation::<C>))
         .route("/mutation/explain", post(post_mutation_explain::<C>))
+        .route("/query/relational", post(post_query_relational::<C>))
+        .route(
+            "/query/relational/stream",
+            post(post_query_relational_stream::<C>),
+        )
         // We want to limit the size of requests to 100MB to prevent various DDoS / SQL overflow
         // vulnerabilities. We use RequestBodyLimit instead of DefaultBodyLimit to include chunked
         // requests, too.
@@ -469,6 +475,480 @@ async fn post_query<C: Connector>(
     WithRejection(Json(request), _): WithRejection<Json<QueryRequest>, JsonRejection>,
 ) -> Result<JsonResponse<QueryResponse>> {
     C::query(state.configuration(), state.state().await?, request).await
+}
+
+async fn post_query_relational<C: Connector>(
+    State(state): State<ServerState<C>>,
+    WithRejection(Json(request), _): WithRejection<Json<RelationalQuery>, JsonRejection>,
+) -> Result<JsonResponse<RelationalQueryResponse>> {
+    C::query_relational(state.configuration(), state.state().await?, request).await
+}
+
+async fn post_query_relational_stream<C: Connector>(
+    State(state): State<ServerState<C>>,
+    WithRejection(Json(request), _): WithRejection<Json<RelationalQuery>, JsonRejection>,
+) -> std::result::Result<impl axum::response::IntoResponse, ErrorResponse> {
+    use futures_util::StreamExt;
+
+    let span = tracing::Span::current();
+    let stream = C::query_relational_stream(state.configuration(), state.state().await?, request)
+        .await?
+        .map(move |row_result| match row_result {
+            Ok(row) => match serde_json::to_vec(&row) {
+                Ok(mut json_line) => {
+                    json_line.push(b'\n');
+                    Ok(json_line)
+                }
+                Err(err) => {
+                    let err = ErrorResponse::from_error(err);
+                    tracing::error!(
+                        parent: &span,
+                        meta.signal_type = "log",
+                        event.domain = "ndc",
+                        event.name = "Relational stream serialization failure",
+                        name = "Relational stream serialization failure",
+                        body = %err,
+                        error = true,
+                    );
+                    Err(err)
+                }
+            },
+            Err(err) => {
+                tracing::error!(
+                    parent: &span,
+                    meta.signal_type = "log",
+                    event.domain = "ndc",
+                    event.name = "Relational stream failure",
+                    name = "Relational stream failure",
+                    body = %err,
+                    error = true,
+                );
+                Err(err)
+            }
+        });
+
+    Ok((
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/x-ndjson; charset=utf-8",
+        )],
+        axum::body::Body::from_stream(stream),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::error::Error;
+    use std::net::SocketAddr;
+
+    use async_trait::async_trait;
+    use futures_util::stream::{self, BoxStream, StreamExt as _};
+    use http::StatusCode;
+    use prometheus::Registry;
+    use serde_json::json;
+
+    use crate::connector::NotSupported;
+    use crate::state::ServerState;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestSetup<C: Connector> {
+        state: C::State,
+    }
+
+    #[async_trait]
+    impl<C> ConnectorSetup for TestSetup<C>
+    where
+        C: Connector,
+        C::Configuration: Default,
+        C::State: Clone,
+    {
+        type Connector = C;
+
+        async fn parse_configuration(
+            &self,
+            _configuration_dir: &std::path::Path,
+        ) -> Result<<Self::Connector as Connector>::Configuration> {
+            Ok(Default::default())
+        }
+
+        async fn try_init_state(
+            &self,
+            _configuration: &<Self::Connector as Connector>::Configuration,
+            _metrics: &mut Registry,
+        ) -> Result<<Self::Connector as Connector>::State> {
+            Ok(self.state.clone())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct TestState {
+        relational_rows: Vec<Vec<serde_json::Value>>,
+        stream_rows: Vec<std::result::Result<Vec<serde_json::Value>, String>>,
+    }
+
+    struct DefaultRelationalConnector;
+
+    #[async_trait]
+    impl Connector for DefaultRelationalConnector {
+        type Configuration = ();
+        type State = ();
+
+        fn connector_name() -> &'static str {
+            "default-relational"
+        }
+
+        fn connector_version() -> &'static str {
+            "test"
+        }
+
+        fn fetch_metrics(_configuration: &Self::Configuration, _state: &Self::State) -> Result<()> {
+            Ok(())
+        }
+
+        async fn get_capabilities() -> ndc_models::Capabilities {
+            empty_capabilities()
+        }
+
+        async fn get_schema(
+            _configuration: &Self::Configuration,
+        ) -> Result<JsonResponse<SchemaResponse>> {
+            Ok(empty_schema().into())
+        }
+
+        async fn query_explain(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: QueryRequest,
+        ) -> Result<JsonResponse<ExplainResponse>> {
+            Err(NotSupported::with_message("query explain not used in test").into())
+        }
+
+        async fn mutation_explain(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: MutationRequest,
+        ) -> Result<JsonResponse<ExplainResponse>> {
+            Err(NotSupported::with_message("mutation explain not used in test").into())
+        }
+
+        async fn mutation(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: MutationRequest,
+        ) -> Result<JsonResponse<MutationResponse>> {
+            Err(NotSupported::with_message("mutation not used in test").into())
+        }
+
+        async fn query(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: QueryRequest,
+        ) -> Result<JsonResponse<QueryResponse>> {
+            Err(NotSupported::with_message("query not used in test").into())
+        }
+    }
+
+    struct RelationalConnector;
+
+    #[async_trait]
+    impl Connector for RelationalConnector {
+        type Configuration = ();
+        type State = TestState;
+
+        fn connector_name() -> &'static str {
+            "relational"
+        }
+
+        fn connector_version() -> &'static str {
+            "test"
+        }
+
+        fn fetch_metrics(_configuration: &Self::Configuration, _state: &Self::State) -> Result<()> {
+            Ok(())
+        }
+
+        async fn get_capabilities() -> ndc_models::Capabilities {
+            empty_capabilities()
+        }
+
+        async fn get_schema(
+            _configuration: &Self::Configuration,
+        ) -> Result<JsonResponse<SchemaResponse>> {
+            Ok(empty_schema().into())
+        }
+
+        async fn query_explain(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: QueryRequest,
+        ) -> Result<JsonResponse<ExplainResponse>> {
+            Err(NotSupported::with_message("query explain not used in test").into())
+        }
+
+        async fn mutation_explain(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: MutationRequest,
+        ) -> Result<JsonResponse<ExplainResponse>> {
+            Err(NotSupported::with_message("mutation explain not used in test").into())
+        }
+
+        async fn mutation(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: MutationRequest,
+        ) -> Result<JsonResponse<MutationResponse>> {
+            Err(NotSupported::with_message("mutation not used in test").into())
+        }
+
+        async fn query(
+            _configuration: &Self::Configuration,
+            _state: &Self::State,
+            _request: QueryRequest,
+        ) -> Result<JsonResponse<QueryResponse>> {
+            Err(NotSupported::with_message("query not used in test").into())
+        }
+
+        async fn query_relational(
+            _configuration: &Self::Configuration,
+            state: &Self::State,
+            _request: RelationalQuery,
+        ) -> Result<JsonResponse<RelationalQueryResponse>> {
+            Ok(RelationalQueryResponse {
+                rows: state.relational_rows.clone(),
+            }
+            .into())
+        }
+
+        async fn query_relational_stream(
+            _configuration: &Self::Configuration,
+            state: &Self::State,
+            _request: RelationalQuery,
+        ) -> Result<BoxStream<'static, Result<Vec<serde_json::Value>>>> {
+            let stream = stream::iter(state.stream_rows.clone().into_iter().map(|item| {
+                item.map_err(|message| {
+                    ErrorResponse::new(StatusCode::BAD_GATEWAY, message, serde_json::Value::Null)
+                })
+            }))
+            .boxed();
+
+            Ok(stream)
+        }
+    }
+
+    struct TestServer {
+        address: SocketAddr,
+        client: reqwest::Client,
+    }
+
+    impl TestServer {
+        async fn new(
+            router: axum::Router,
+        ) -> std::result::Result<Self, Box<dyn Error + Send + Sync>> {
+            let listener =
+                tokio::net::TcpListener::bind(SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, 0)))
+                    .await?;
+            let address = listener.local_addr()?;
+
+            tokio::spawn(async move {
+                axum::serve(listener, router.into_make_service())
+                    .await
+                    .expect("server error");
+            });
+
+            let client = reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?;
+
+            Ok(Self { address, client })
+        }
+
+        fn post_json(&self, path: &str, body: &RelationalQuery) -> reqwest::RequestBuilder {
+            self.client
+                .post(format!("http://{}{}", self.address, path))
+                .json(body)
+        }
+    }
+
+    #[tokio::test]
+    async fn relational_query_defaults_to_not_implemented(
+    ) -> std::result::Result<(), Box<dyn Error + Send + Sync>> {
+        let state = ServerState::new(
+            (),
+            TestSetup::<DefaultRelationalConnector> { state: () },
+            Registry::new(),
+        );
+        let server = TestServer::new(create_router::<DefaultRelationalConnector>(
+            state, None, None,
+        ))
+        .await?;
+
+        let response = server
+            .post_json("/query/relational", &sample_relational_query())
+            .send()
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(
+            response.json::<ndc_models::ErrorResponse>().await?,
+            ndc_models::ErrorResponse {
+                message: "This operation is not supported by this connector".into(),
+                details: serde_json::Value::Null,
+            }
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn relational_query_route_returns_connector_response(
+    ) -> std::result::Result<(), Box<dyn Error + Send + Sync>> {
+        let state = ServerState::new(
+            (),
+            TestSetup::<RelationalConnector> {
+                state: TestState {
+                    relational_rows: vec![vec![json!(1), json!("two")]],
+                    stream_rows: vec![],
+                },
+            },
+            Registry::new(),
+        );
+        let server =
+            TestServer::new(create_router::<RelationalConnector>(state, None, None)).await?;
+
+        let response = server
+            .post_json("/query/relational", &sample_relational_query())
+            .send()
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.json::<RelationalQueryResponse>().await?,
+            RelationalQueryResponse {
+                rows: vec![vec![json!(1), json!("two")]],
+            }
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn relational_stream_route_returns_ndjson(
+    ) -> std::result::Result<(), Box<dyn Error + Send + Sync>> {
+        let state = ServerState::new(
+            (),
+            TestSetup::<RelationalConnector> {
+                state: TestState {
+                    relational_rows: vec![],
+                    stream_rows: vec![
+                        Ok(vec![json!(1), json!("two")]),
+                        Ok(vec![json!(3), json!("four")]),
+                    ],
+                },
+            },
+            Registry::new(),
+        );
+        let server =
+            TestServer::new(create_router::<RelationalConnector>(state, None, None)).await?;
+
+        let response = server
+            .post_json("/query/relational/stream", &sample_relational_query())
+            .send()
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .unwrap(),
+            "application/x-ndjson; charset=utf-8"
+        );
+        assert_eq!(response.text().await?, "[1,\"two\"]\n[3,\"four\"]\n");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn relational_stream_route_propagates_stream_errors(
+    ) -> std::result::Result<(), Box<dyn Error + Send + Sync>> {
+        let state = ServerState::new(
+            (),
+            TestSetup::<RelationalConnector> {
+                state: TestState {
+                    relational_rows: vec![],
+                    stream_rows: vec![Ok(vec![json!(1)]), Err("stream failed".into())],
+                },
+            },
+            Registry::new(),
+        );
+        let server =
+            TestServer::new(create_router::<RelationalConnector>(state, None, None)).await?;
+
+        let error = server
+            .post_json("/query/relational/stream", &sample_relational_query())
+            .send()
+            .await
+            .expect_err("stream transport should fail once the connector stream errors");
+        assert!(error.is_request());
+
+        Ok(())
+    }
+
+    fn empty_capabilities() -> ndc_models::Capabilities {
+        ndc_models::Capabilities {
+            relationships: None,
+            query: ndc_models::QueryCapabilities {
+                variables: None,
+                aggregates: None,
+                explain: None,
+                nested_fields: ndc_models::NestedFieldCapabilities {
+                    filter_by: None,
+                    order_by: None,
+                    aggregates: None,
+                    nested_collections: None,
+                },
+                exists: ndc_models::ExistsCapabilities {
+                    nested_collections: None,
+                    unrelated: None,
+                    named_scopes: None,
+                    nested_scalar_collections: None,
+                },
+            },
+            mutation: ndc_models::MutationCapabilities {
+                transactional: None,
+                explain: None,
+            },
+            relational_mutation: None,
+            relational_query: None,
+        }
+    }
+
+    fn empty_schema() -> SchemaResponse {
+        SchemaResponse {
+            collections: vec![],
+            functions: vec![],
+            procedures: vec![],
+            object_types: BTreeMap::new(),
+            scalar_types: BTreeMap::new(),
+            capabilities: None,
+            request_arguments: None,
+        }
+    }
+
+    fn sample_relational_query() -> RelationalQuery {
+        RelationalQuery {
+            root_relation: ndc_models::Relation::From {
+                collection: "test_collection".into(),
+                columns: vec![],
+                arguments: BTreeMap::new(),
+            },
+            request_arguments: None,
+        }
+    }
 }
 
 #[cfg(feature = "ndc-test")]

--- a/crates/sdk/src/tracing.rs
+++ b/crates/sdk/src/tracing.rs
@@ -148,7 +148,7 @@ pub fn make_span(request: &Request<Body>) -> Span {
     let parent_context_span = parent_context.span();
     let parent_context_span_context = parent_context_span.span_context();
     if parent_context_span_context.is_valid() {
-        span.set_parent(parent_context);
+        let _ = span.set_parent(parent_context);
     }
 
     span


### PR DESCRIPTION
## Summary

This PR adds support for relational query endpoints in the Rust SDK and updates the SDK to `ndc-spec` `v0.2.12`.

## Changes

- bump `ndc-models` and `ndc-test` to `v0.2.12`
- add optional relational query methods to the `Connector` trait
- add a default `NotSupported` error for unimplemented optional connector operations
- expose `/query/relational` and `/query/relational/stream` in the default SDK router
- return NDJSON for streaming relational query responses
- propagate streaming failures as actual stream failures instead of encoding fake error rows
- log streaming failures and serialization failures under the request span
- add endpoint-level tests for:
  - default `501 Not Implemented` behavior
  - relational query route wiring
  - NDJSON content type and framing
  - stream error propagation

## Validation

- `cargo fmt --check`
- `cargo check -q`
- `cargo test -q default_main::tests --package ndc-sdk`
- `cargo clippy -q --all-targets --all-features -- -D warnings`

## Notes

The new endpoints inherit the existing request tracing middleware. Stream failures are now logged against the request span, but request latency still reflects response creation time rather than full stream completion time.